### PR TITLE
Replace UnitRange by StepRange with a unit step

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OddEvenIntegers"
 uuid = "8d37c425-f37a-4ca2-9b9d-a61bc06559d2"
 authors = ["Jishnu Bhattacharya <jishnub.github@gmail.com> and contributors"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"

--- a/src/OddEvenIntegers.jl
+++ b/src/OddEvenIntegers.jl
@@ -180,25 +180,18 @@ Base.zero(::Type{HalfOddInteger{T}}) where {T<:Integer} = zero(Half{T})
 Base.iszero(::HalfOddInteger) = false
 Base.isone(::HalfOddInteger) = false
 
-# We can't have a HalfOddInt 1, as we can't have an Odd 2. We therefore need to work around this
-Base.step(r::UnitRange{HalfOddInteger{T}}) where {T<:Integer} = oneunit(T)
-
-# Special case UnitRanges/StepRanges with start/stop being a HalfOddInteger, and the other being an integer
-# Eg. half(Odd(1)):5 == half(Odd(1)):half(Odd(9)), and it may have an eltype of Half{Odd{Int}}
-# these methods are needed to avoid promotion to `HalfInt`
-
-function _unitrange_ofeltype(start, stop, ::Type{T}) where {T}
-	startstop_promoted = map(T, promote(start, stop))
-	UnitRange(startstop_promoted...)
+function _unitsteprange_ofeltype(start, stop, ::Type{T}) where {T}
+	startT, stopT = convert.(T, promote(start, stop))
+	StepRange(startT, Integer(oneunit(stopT-startT)), stopT)
 end
 function _range_decreasestop(start, stop, T::Type)
 	stop_shifted = stop - half(1)
-	_unitrange_ofeltype(start, stop_shifted, T)
+	_unitsteprange_ofeltype(start, stop_shifted, T)
 end
 Base.:(:)(start::HalfOddInteger, stop::Integer) = _range_decreasestop(start, stop, HalfOddInteger)
 Base.:(:)(start::Integer, stop::HalfOddInteger) = _range_decreasestop(start, stop, Integer)
 function Base.:(:)(start::HalfOddInteger, stop::HalfOddInteger)
-	_unitrange_ofeltype(start, stop, HalfOddInteger)
+	_unitsteprange_ofeltype(start, stop, HalfOddInteger)
 end
 
 function _steprange_ofeltype(start, step::Integer, stop, ::Type{T}) where {T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,6 +194,8 @@ end
             @test x - y == -1
             @test x != 1
             @test 1 != x
+            @test OddEvenIntegers.HalfOddInteger(x) === x
+            @test OddEvenIntegers.HalfOddInteger(half(3)) === x
 
             @test half(Odd(typemax(Int))) + half(Odd(typemax(Int))) == typemax(Int)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -303,8 +303,10 @@ end
                 s = (:)(map(_integer_or_halfinteger, (start, stop))...)
                 @test r == s
                 @test length(r) == length(s) == length(collect(r))
-                @test r isa UnitRange{T}
-                @test first(r) isa T
+                @test r isa AbstractRange{T}
+                @test @inferred(step(r)) == 1
+                @test @inferred(first(r)) isa T
+                @test @inferred(r[1]) isa T
             end
             @testset "UnitRange" begin
                 @testset "Odd{Int}" begin
@@ -330,24 +332,28 @@ end
                 end
             end
 
-            function test_range(start, _step, stop, T, S)
-                r = @inferred start:_step:stop
-                s = (:)(map(_integer_or_halfinteger, (start, _step, stop))...)
+            function test_range(start, stepsize, stop, T, S)
+                r = @inferred start:stepsize:stop
+                s = (:)(map(_integer_or_halfinteger, (start, stepsize, stop))...)
                 @test r == s
                 @test length(r) == length(s) == length(collect(r))
                 @test r isa StepRange{T,S}
-                @test first(r) isa T
-                @test step(r) isa S
+                @test @inferred(first(r)) isa T
+                if length(r) > 0
+                    @test @inferred(r[1]) isa T
+                end
+                @test @inferred(step(r)) isa S
             end
 
             @testset "StepRange" begin
                 @testset "Odd{Int}" begin
-                    for step in [-2:-1; 1:2]
-                        test_range(half(Odd(1)), step, half(Odd(19)), Half{Odd{Int}}, Int)
+                    for stepsize in [-2:-1; 1:2]
+                        test_range(half(Odd(1)), stepsize, half(Odd(19)), Half{Odd{Int}}, Int)
+                        test_range(half(Odd(19)), stepsize, half(Odd(1)), Half{Odd{Int}}, Int)
 
-                        test_range(half(Odd(1)), step, 25, Half{Odd{Int}}, Int)
+                        test_range(half(Odd(1)), stepsize, 25, Half{Odd{Int}}, Int)
 
-                        test_range(2, step, half(Odd(17)), Int, Int)
+                        test_range(2, stepsize, half(Odd(17)), Int, Int)
                     end
                     @test_throws ArgumentError half(Odd(1)):0:2
                     @test_throws ArgumentError 2:0:half(Odd(3))
@@ -355,18 +361,20 @@ end
                 end
 
                 @testset "Odd{BigInt}" begin
-                    for step in [-2:-1; 1:2]
-                        test_range(half(Odd(big(1))), step, half(Odd(19)), Half{Odd{BigInt}}, BigInt)
-                        test_range(half(Odd(1)), big(step), half(Odd(19)), Half{Odd{BigInt}}, BigInt)
-                        test_range(half(Odd(1)), step, half(Odd(big(19))), Half{Odd{BigInt}}, BigInt)
+                    for stepsize in [-2:-1; 1:2]
+                        test_range(half(Odd(big(1))), stepsize, half(Odd(19)), Half{Odd{BigInt}}, BigInt)
+                        test_range(half(Odd(1)), big(stepsize), half(Odd(19)), Half{Odd{BigInt}}, BigInt)
+                        test_range(half(Odd(1)), stepsize, half(Odd(big(19))), Half{Odd{BigInt}}, BigInt)
 
-                        test_range(half(Odd(big(1))), step, 10, Half{Odd{BigInt}}, BigInt)
-                        test_range(half(Odd(1)), big(step), 10, Half{Odd{BigInt}}, BigInt)
-                        test_range(half(Odd(1)), step, big(10), Half{Odd{BigInt}}, BigInt)
+                        test_range(half(Odd(19)), stepsize, half(Odd(big(1))), Half{Odd{BigInt}}, BigInt)
 
-                        test_range(big(2), step, half(Odd(19)), BigInt, BigInt)
-                        test_range(2, big(step), half(Odd(19)), BigInt, BigInt)
-                        test_range(2, step, half(Odd(big(19))), BigInt, BigInt)
+                        test_range(half(Odd(big(1))), stepsize, 10, Half{Odd{BigInt}}, BigInt)
+                        test_range(half(Odd(1)), big(stepsize), 10, Half{Odd{BigInt}}, BigInt)
+                        test_range(half(Odd(1)), stepsize, big(10), Half{Odd{BigInt}}, BigInt)
+
+                        test_range(big(2), stepsize, half(Odd(19)), BigInt, BigInt)
+                        test_range(2, big(stepsize), half(Odd(19)), BigInt, BigInt)
+                        test_range(2, stepsize, half(Odd(big(19))), BigInt, BigInt)
                     end
 
                     @test_throws ArgumentError half(Odd(1)):big(0):2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -306,7 +306,12 @@ end
                 @test r isa AbstractRange{T}
                 @test @inferred(step(r)) == 1
                 @test @inferred(first(r)) isa T
-                @test @inferred(r[1]) isa T
+                if length(r) > 0
+                    @test @inferred(r[1]) isa T
+                end
+                if length(r) > 1
+                    @test @inferred(r[2]) isa T
+                end
             end
             @testset "UnitRange" begin
                 @testset "Odd{Int}" begin
@@ -341,6 +346,9 @@ end
                 @test @inferred(first(r)) isa T
                 if length(r) > 0
                     @test @inferred(r[1]) isa T
+                end
+                if length(r) > 1
+                    @test @inferred(r[2]) isa T
                 end
                 @test @inferred(step(r)) isa S
             end


### PR DESCRIPTION
This changes
```julia
julia> half(Odd(1)):half(Odd(5))
1/2:5/2

julia> half(Odd(1)):half(Odd(5)) |> typeof
UnitRange{Half{Odd{Int64}}}
```
to
```julia
julia> half(Odd(1)):half(Odd(5))
1/2:1:5/2

julia> half(Odd(1)):half(Odd(5)) |> typeof
StepRange{Half{Odd{Int64}}, Int64}
```