### PR TITLE
Don't specialize oneunit for Even

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OddEvenIntegers"
 uuid = "8d37c425-f37a-4ca2-9b9d-a61bc06559d2"
 authors = ["Jishnu Bhattacharya <jishnub.github@gmail.com> and contributors"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 HalfIntegers = "f0d1745a-41c9-11e9-1dd9-e5d34d218721"

--- a/src/OddEvenIntegers.jl
+++ b/src/OddEvenIntegers.jl
@@ -122,8 +122,6 @@ Base.zero(::Type{Odd{T}}) where {T<:Integer} = zero(T)
 
 Base.one(x::Even) = one(x.x)
 Base.one(::Type{Even{T}}) where {T} = one(T)
-# hack around the fact that we can't have an even 1
-Base.oneunit(x::Even) = oneunit(x.x)
 
 Base.show(io::IO, @nospecialize(x::AbstractOddEvenInteger)) = print(io, x.x)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,7 +108,7 @@ end
         @test Base.checked_abs(-x) == 4
         @test zero(x) == Even(0) == 0
         @test one(x) == 1
-        @test oneunit(x) == 1
+        @test_throws DomainError oneunit(x)
         @test trailing_zeros(x) == 2
         @test rem(x, x) == 0
         @test div(x, x) == 1
@@ -127,8 +127,6 @@ end
 
         if VERSION >= v"1.8"
             @test range(Even(2), length=2) == 2:3
-            @test range(2, length=Even(2)) == 2:3
-            @test range(Even(2), length=Even(2)) == 2:3
             @test Even(2):10 == 2:10
             @test Even(2):Even(2):10 == 2:2:10
             @test 2:Even(2):10 == 2:2:10


### PR DESCRIPTION
This definition is wrong, and implementing it as a hack perhaps isn't the right approach.